### PR TITLE
add trainingroom MatchType and UNKNOWN as default value 

### DIFF
--- a/src/main/java/com/github/gplnature/pubgapi/model/MatchType.java
+++ b/src/main/java/com/github/gplnature/pubgapi/model/MatchType.java
@@ -1,5 +1,6 @@
 package com.github.gplnature.pubgapi.model;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum MatchType {
@@ -8,10 +9,12 @@ public enum MatchType {
     @JsonProperty("event") EVENT("event"),
     @JsonProperty("official") OFFICIAL("official"),
     @JsonProperty("training") TRAINING("training"),
+    @JsonProperty("trainingroom") TRAININGROOM("trainingroom"),
     @JsonProperty("competitive") COMPETITIVE("competitive"),
     @JsonProperty("airoyale") AIROYALE("airoyale"),
     @JsonProperty("seasonal") SEASONAL("seasonal"),
-    @JsonProperty("tutorialatoz") TUTORIALATOZ("tutorialatoz");
+    @JsonProperty("tutorialatoz") TUTORIALATOZ("tutorialatoz"),
+    @JsonEnumDefaultValue @JsonProperty("unknown") UNKNOWN("unknown");
 
     private final String text;
 


### PR DESCRIPTION
add trainingroom MatchType and UNKNOWN (just like in GameMode) as default value to avoid exceptions. 

Got this error:
com.github.gplnature.pubgapi.exception.PubgClientException: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `com.github.gplnature.pubgapi.model.MatchType` from String "trainingroom": not one of the values accepted for Enum class: [arcade, custom, airoyale, training, official, tutorialatoz, seasonal, competitive, event]