### PR TITLE
Annotation for SeasonAttributes.isCurrentSeason to ensure that the value is assigned

### DIFF
--- a/src/main/java/com/github/gplnature/pubgapi/model/season/SeasonAttributes.java
+++ b/src/main/java/com/github/gplnature/pubgapi/model/season/SeasonAttributes.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class SeasonAttributes {
 
+    @JsonProperty("isCurrentSeason")
     private Boolean isCurrentSeason;
 
     @JsonProperty("isOffseason")


### PR DESCRIPTION
If you call pubgClient.getSeasons()   the value for SeasonAttributes.isCurrentSeason was always null.
With the json annotation the value is assigned. 
